### PR TITLE
(Gizmo init.lua) Fix No terrain object found under workspace...

### DIFF
--- a/src/Dependencies/Gizmo/init.lua
+++ b/src/Dependencies/Gizmo/init.lua
@@ -5,7 +5,7 @@
 
 local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
-local Terrain = workspace:WaitForChild("Terrain",10)
+local Terrain = workspace:WaitForChild("Terrain",5)
 
 assert(Terrain, "No terrain object found under workspace...")
 

--- a/src/Dependencies/Gizmo/init.lua
+++ b/src/Dependencies/Gizmo/init.lua
@@ -5,7 +5,7 @@
 
 local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
-local Terrain = workspace:FindFirstChild("Terrain")
+local Terrain = workspace:WaitForChild("Terrain",10)
 
 assert(Terrain, "No terrain object found under workspace...")
 


### PR DESCRIPTION
Sometime as I test Terrain loaded after Gizmo